### PR TITLE
staking button disabled till pendinclaim higher then 0

### DIFF
--- a/src/components/ConnectWallet.jsx
+++ b/src/components/ConnectWallet.jsx
@@ -571,10 +571,10 @@ export default function ConnectWallet() {
         window.addEventListener('scroll', handleScroll)
     }, [
         connectedWallet,
-        lcd,
-        state.config,
-        state.allRecentWinners,
-        state.youWon,
+        // lcd,
+        // state.config,
+        // state.allRecentWinners,
+        // state.youWon,
     ])
 
     return (

--- a/src/components/StakingForm.jsx
+++ b/src/components/StakingForm.jsx
@@ -20,7 +20,7 @@ export default function StakingForm(props) {
 
     useEffect(() => {
         blockHeight()
-    }, [blockHeight])
+    }, [])
 
     return (
         <div className="card lota-card staking">
@@ -74,7 +74,7 @@ export default function StakingForm(props) {
                             role="tabpanel"
                             aria-labelledby="pills-staking-tab"
                         >
-                            <Staking showNotification={showNotification} />
+                            <Staking showNotification={showNotification} heightBlock={heightBlock} />
                         </div>
                         <div
                             className="tab-pane fade"

--- a/src/components/StakingForm/LpStaking.jsx
+++ b/src/components/StakingForm/LpStaking.jsx
@@ -90,7 +90,7 @@ export default function LpStaking(props) {
                     total_amount_claimable += parseInt(e.amount)
                 }
             })
-            return total_amount_claimable / 1000000
+            return parseInt(total_amount_claimable / 1000000)
         }
         return 0
     }
@@ -102,7 +102,7 @@ export default function LpStaking(props) {
                     total_amount_pending += parseInt(e.amount)
                 }
             })
-            return total_amount_pending / 1000000
+            return parseInt(total_amount_pending / 1000000)
         }
         return 0
     }
@@ -395,7 +395,7 @@ export default function LpStaking(props) {
                                                 </button>
                                             </div>
 
-            { claimInfo() && pendingClaim() && pendingClaim() > 0 || claimInfo() > 0 &&
+            {pendingClaim() > 0 || claimInfo() > 0 &&
              <div className="col-md-12 my-3">
                 <div className="claim-unstake">
                     <p className="input-heading">Claim unstake</p>

--- a/src/components/StakingForm/Staking.jsx
+++ b/src/components/StakingForm/Staking.jsx
@@ -9,7 +9,7 @@ const addToGas = 5800
 const obj = new StdFee(700_000, { uusd: 319200 + addToGas })
 
 export default function Staking(props) {
-    const { showNotification } = props
+    const { showNotification,heightBlock } = props
     const { state, dispatch } = useStore()
 
     function setInputAmount(amount) {
@@ -71,26 +71,26 @@ export default function Staking(props) {
     }
 
     function claimInfo() {
-        if (state.holderClaims) {
+        if (state.holderClaims.length > 0) {
             let total_amount_claimable = 0
             state.holderClaims.map((e) => {
-                if (e.release_at.at_height < state.blockHeight) {
+                if (e.release_at.at_height < heightBlock) {
                     total_amount_claimable += parseInt(e.amount)
                 }
             })
-            return total_amount_claimable / 1000000
+            return parseInt(total_amount_claimable / 1000000)
         }
         return 0
     }
     function pendingClaim() {
-        if (state.holderClaims) {
+        if (state.holderClaims.length > 0) {
             let total_amount_pending = 0
             state.holderClaims.map((e) => {
-                if (e.release_at.at_height > state.blockHeight) {
+                if (e.release_at.at_height > heightBlock) {
                     total_amount_pending += parseInt(e.amount)
                 }
             })
-            return total_amount_pending / 1000000
+            return parseInt(total_amount_pending / 1000000)
         }
         return 0
     }
@@ -290,8 +290,8 @@ export default function Staking(props) {
                                                     Claim rewards
                                                 </button>
                                          
-            </div>
-            { pendingClaim() > 0 || claimInfo() > 0 &&
+            </div>         
+            {claimInfo() > 0 || pendingClaim() > 0 &&
                 <div className="col-md-12 my-3">
                 <div className="claim-unstake">
                     <button
@@ -321,15 +321,16 @@ export default function Staking(props) {
                                     </td>
                                 </tr>
                             </thead>
-                            <tbody>
+                            <tbody>                                
                                 {state.holderClaims ? (
                                     state.holderClaims.map((e) => {
                                         if (
                                             e.release_at.at_height >
-                                            state.blockHeight
+                                            heightBlock
                                         ) {
-                                            return (
-                                                <tr>
+                                       
+                                                return (
+                                                    <tr>
                                                     <td
                                                         style={{
                                                             paddingLeft: '20px',
@@ -349,7 +350,8 @@ export default function Staking(props) {
                                                         {e.release_at.at_height}
                                                     </td>
                                                 </tr>
-                                            )
+                                                )
+                                            
                                         }
                                     })
                                 ) : (

--- a/src/components/StakingForm/Staking.jsx
+++ b/src/components/StakingForm/Staking.jsx
@@ -296,6 +296,7 @@ export default function Staking(props) {
                 <div className="claim-unstake">
                     <button
                         className="btn btn-default-lg w-100"
+                        disabled={claimInfo() > 0 ? false : true }
                         onClick={() => claimUnstake()}
                         style={{ marginTop: '21px' }}
                     >


### PR DESCRIPTION
Mentioned by a customer, double checked and found that claim button is not disabled on staking when blockheight is still higher. i added a condition for this now